### PR TITLE
Gamepad Mode

### DIFF
--- a/FancyActionBar+/init.lua
+++ b/FancyActionBar+/init.lua
@@ -3,7 +3,7 @@
 --- @field style integer # 1 for keyboard, 2 for gamepad
 --- @field updateUI boolean # Flag to determine if UI needs updating
 --- @field constants FancyActionBarConstants
---- @field useGamepadActionBar boolean # Force enable gamepad actionbar style
+--- @field useGamepadActionBar boolean # Gamepad-style action bar is currently active
 FancyActionBar = {}
 FancyActionBar.__index = FancyActionBar
 
@@ -11,6 +11,12 @@ FancyActionBar.__index = FancyActionBar
 local FancyActionBar = FancyActionBar
 
 FancyActionBar.variableVersion = 1
+
+FancyActionBar.GAMEPAD_MODE = {
+    AUTOMATIC = 1, -- follow ESO's gamepad preferred mode
+    GAMEPAD   = 2, -- always use gamepad-style bar
+    KEYBOARD  = 3, -- always use keyboard-style bar
+}
 
 FancyActionBar.defaultCharacter =
 {
@@ -34,7 +40,10 @@ FancyActionBar.defaultSettings =
 
     configChanges = {},
     dynamicAbilityConfig = false,
+    -- old boolean, kept for backward compatibility
     forceGamepadStyle = false,
+    -- new enum-backed mode
+    gamepadMode = FancyActionBar.GAMEPAD_MODE.AUTOMATIC,
 
     externalBuffs = false,
     externalBlackListRun = false,

--- a/FancyActionBar+/presets.lua
+++ b/FancyActionBar+/presets.lua
@@ -307,7 +307,7 @@ FancyActionBar.devConfig =
         [2] = 0,
         [3] = 0.3921568692,
     },
-    ["forceGamepadStyle"] = true,
+    ["gamepadMode"] = FancyActionBar.GAMEPAD_MODE.GAMEPAD,
     ["ultFillBarAlpha"] = 1,
     ["fontNameStackKB"] = "Univers 67",
     ["ultValueTypeGP"] = "outline",


### PR DESCRIPTION
This awesome addon already supports a flag to optionally force gamepad UI when using keyboard. This change migrates to a symmetrical enumerated setting that allows optionally forcing either gamepad or keyboard UI regardless of control in use.

The use case is that I use keyboard usually, and prefer keyboard UI,  but do use a controller occasionally. I use too many addons for it to be practical to manually adjust UI layout when I switch to a gamepad.
